### PR TITLE
Wrap _Inherited's child with Builder.

### DIFF
--- a/lib/src/bloc_provider.dart
+++ b/lib/src/bloc_provider.dart
@@ -201,7 +201,9 @@ class _BlocProviderState<BlocType extends Bloc>
   Widget build(BuildContext context) {
     return _Inherited<BlocType>(
       bloc: _bloc,
-      child: widget.builder(context, _bloc),
+      child: Builder(
+        builder: (context) => widget.builder(context, _bloc),
+      ),
     );
   }
 


### PR DESCRIPTION
This fixes inability to use `BlocProvider.builder`'s context to retrieve a Bloc provided in `creator`.

Example of a structure that works with this change and doesn't work without it:

```dart
  @override
  Widget build(BuildContext context) {
    return BlocProvider.builder(
      creator: (context, _) {
        return MainBloc();
      },
      builder: (context, _) => Scaffold(
        body: _content(context),
      ),
    );
  }

Widget _content(BuildContext context) {
  return Text(MainBloc.of(context).runtimeType.toString());
}
```