### PR TITLE
updated for latest rxdart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Provides BLoC(Business Logic Component) to descendant widget (O(1)), and the blo
 
 ```dart
 class CounterBloc implements Bloc {
-  final _countController = BehaviorSubject<int>(seedValue: 0);
+  final _countController = BehaviorSubject<int>.seeded(0);
   final _incrementController = PublishSubject<void>();
 
   CounterBloc() {


### PR DESCRIPTION
`BehaviorSubject` initialization now requires calling the `.seeded()` constructor.